### PR TITLE
added en-US as default language

### DIFF
--- a/tools/speech-tester/index.js
+++ b/tools/speech-tester/index.js
@@ -17,7 +17,7 @@ function getRandomInt (max) {
 (async () => {
 
 const [_] = await Promise.all([
-    i18n({localesBasePath: '../../'}),
+    i18n({locales: [...navigator.languages, 'en-US'], localesBasePath: '../../'}),
     loadStylesheets([
         '../../vendor/dialog-polyfill/dialog-polyfill.css',
         '../../vendor/tippy.js/dist/tippy.css',


### PR DESCRIPTION
My navigator.languages is `['en', 'zh-CN', 'zh']`
Then I get those 404 errors.
```
https://raw.githack.com/brettz9/bopomofo/master/_locales/en/messages.json
https://raw.githack.com/brettz9/bopomofo/master/_locales/zh-CN/messages.json
https://raw.githack.com/brettz9/bopomofo/master/_locales/zh/messages.json
```

So I added 'en-US' as the default lanuage.